### PR TITLE
Added debug settings to launch json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,10 @@
 			"name": "Autohotkey v1 Debugger",
 			"program": "${workspaceFolder}/demos/demo_for_ahk_v1.ahk",
 			"runtime": "C:\\Program Files\\Autohotkey\\AutoHotkeyU64.exe",
-			"stopOnEntry": false
+			"stopOnEntry": false,
+			"dbgpSettings": {
+				"max_children": 149,
+			}
 		},
 		{
 			"type": "ahk",
@@ -16,7 +19,10 @@
 			"name": "Autohotkey v2 Debugger",
 			"program": "${workspaceFolder}/demos/demo_for_ahk_v2.ahk",
 			"runtime": "C:\\Program Files\\AutoHotkey\\v2-alpha\\x64\\AutoHotkey.exe", // Default value of Scite for ahk v2
-			"stopOnEntry": false
+			"stopOnEntry": false,
+			"dbgpSettings": {
+				"max_children": 149,
+			}
 		},
 		{
 			"name": "Launch Extension",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
 			"type": "ahk",
 			"request": "launch",
 			"name": "Autohotkey v1 Debugger",
-			"program": "${file}",
+			"program": "${workspaceFolder}/demos/demo_for_ahk_v1.ahk",
 			"runtime": "C:\\Program Files\\Autohotkey\\AutoHotkeyU64.exe",
 			"stopOnEntry": false
 		},
@@ -14,7 +14,7 @@
 			"type": "ahk",
 			"request": "launch",
 			"name": "Autohotkey v2 Debugger",
-			"program": "${file}",
+			"program": "${workspaceFolder}/demos/demo_for_ahk_v2.ahk",
 			"runtime": "C:\\Program Files\\AutoHotkey\\v2-alpha\\x64\\AutoHotkey.exe", // Default value of Scite for ahk v2
 			"stopOnEntry": false
 		},

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,8 +5,17 @@
 		{
 			"type": "ahk",
 			"request": "launch",
-			"name": "Autohotkey Debugger",
+			"name": "Autohotkey v1 Debugger",
 			"program": "${file}",
+			"runtime": "C:\\Program Files\\Autohotkey\\AutoHotkeyU64.exe",
+			"stopOnEntry": false
+		},
+		{
+			"type": "ahk",
+			"request": "launch",
+			"name": "Autohotkey v2 Debugger",
+			"program": "${file}",
+			"runtime": "C:\\Program Files\\AutoHotkey\\v2-alpha\\x64\\AutoHotkey.exe", // Default value of Scite for ahk v2
 			"stopOnEntry": false
 		},
 		{

--- a/package.json
+++ b/package.json
@@ -74,7 +74,24 @@
 								"type": "boolean",
 								"description": "Enable logging of the Debug Adapter Protocol.",
 								"default": true
-							}
+							},
+							"dbgpSettings": {
+								"type": "object",
+								"properties": {
+								  "max_children": {
+									"type": "integer",
+									"description": "max number of array or object children to initially retrieve",
+									"default": 300
+								  },
+								  "max_data": {
+									"type": "integer",
+									"description": "max amount of variable data to initially retrieve.",
+									"default": 131072
+								  }
+								},
+								"description": "Dbgp settings. See https://xdebug.org/docs-dbgp.php#feature-names",
+								"default": {}
+						  	}
 						}
 					}
 				},

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
 								"description": "Absolute path to a text file.",
 								"default": "${file}"
 							},
+							"runtime": {
+								"type": "string",
+								"description": "Absolute path to a AutoHotkey.exe file.",
+								"default": "C:\\Program Files\\Autohotkey\\AutoHotkeyU64.exe"
+							},
 							"stopOnEntry": {
 								"type": "boolean",
 								"description": "Automatically stop after launch.",

--- a/src/core/ScriptRunner.ts
+++ b/src/core/ScriptRunner.ts
@@ -29,12 +29,14 @@ export class ScriptRunner {
 
     /**
      * run/debug script
+     * @param executePath runtime path
      * @param path execute script path
      * @param debug enable debug model?
      * @param debugPort debug proxy port
      */
-    public async run(path: string = null, debug: boolean = false, debugPort = 9000) {
-        const executePath = await this.buildExecutePath();
+    public async run(executePath = null, path: string = null, debug: boolean = false, debugPort = 9000) {
+        executePath = executePath ? executePath : await this.buildExecutePath();
+
         if (executePath) {
             path = path ? path : vscode.window.activeTextEditor.document.fileName;
             await Process.exec(`\"${executePath}\"${debug ? ' /debug=localhost:' + debugPort : ''} \"${path}\"`, {cwd: `${res(path, '..')}`});

--- a/src/debugger/AhkDebug.ts
+++ b/src/debugger/AhkDebug.ts
@@ -31,6 +31,8 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	stopOnEntry?: boolean;
 	/** enable logging the Debug Adapter Protocol */
 	trace?: boolean;
+	/** An absolute path to the AutoHotkey.exe. */
+	runtime: string;
 }
 
 export class AhkDebugSession extends LoggingDebugSession {
@@ -143,7 +145,7 @@ export class AhkDebugSession extends LoggingDebugSession {
 		logger.setup(args.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false);
 
 		// start the program in the runtime
-		this._runtime.start(args.program, !!args.stopOnEntry);
+		this._runtime.start(args.program, !!args.stopOnEntry, args.runtime);
 
 		this.sendResponse(response);
 	}

--- a/src/debugger/AhkDebug.ts
+++ b/src/debugger/AhkDebug.ts
@@ -24,7 +24,7 @@ import { AhkRuntime, AhkBreakpoint } from './AhkRuntime';
  * The schema for these attributes lives in the package.json of the mock-debug extension.
  * The interface should always match this schema.
  */
-interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
+export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	/** An absolute path to the "program" to debug. */
 	program: string;
 	/** Automatically stop target after launch. If not specified, target does not stop. */
@@ -33,6 +33,10 @@ interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	trace?: boolean;
 	/** An absolute path to the AutoHotkey.exe. */
 	runtime: string;
+	dbgpSettings: {
+		max_children: number;
+		max_data: number;
+	}
 }
 
 export class AhkDebugSession extends LoggingDebugSession {
@@ -145,7 +149,7 @@ export class AhkDebugSession extends LoggingDebugSession {
 		logger.setup(args.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false);
 
 		// start the program in the runtime
-		this._runtime.start(args.program, !!args.stopOnEntry, args.runtime);
+		this._runtime.start(args);
 
 		this.sendResponse(response);
 	}

--- a/src/debugger/AhkRuntime.ts
+++ b/src/debugger/AhkRuntime.ts
@@ -60,7 +60,6 @@ export class AhkRuntime extends EventEmitter {
 	 */
 	public async start(program: string, stopOnEntry: boolean, runtime?: string) {
 
-		program = vscode.window.activeTextEditor.document.uri.fsPath;
 		this.loadSource(program);
 		let tempData = '';
 		const port = await getPort({ port: getPort.makeRange(9000, 9100) });

--- a/src/debugger/AhkRuntime.ts
+++ b/src/debugger/AhkRuntime.ts
@@ -58,7 +58,7 @@ export class AhkRuntime extends EventEmitter {
 	/**
 	 * Start executing the given program.
 	 */
-	public async start(program: string, stopOnEntry: boolean) {
+	public async start(program: string, stopOnEntry: boolean, runtime?: string) {
 
 		program = vscode.window.activeTextEditor.document.uri.fsPath;
 		this.loadSource(program);
@@ -90,7 +90,7 @@ export class AhkRuntime extends EventEmitter {
 		}).on("error", (err: Error) => {
 			Out.log(err.message);
 		});
-		if (!(await ScriptRunner.instance.run(program, true, port))) {
+		if (!(await ScriptRunner.instance.run(runtime, program, true, port))) {
 			this.stop();
 			this.sendEvent('end');
 		}


### PR DESCRIPTION
**By Google Translate from Japanese to English.**

I am writing a library for both Autohotkey v1 and v2 in separate branches.
So it's useful to be able to switch runtimes as branches switch.
Also, since the file to be tested is basically fixed, it is more convenient if you can specify the debug target.
That's why I added this feature.

Thank you.