### PR TITLE
Support set variable

### DIFF
--- a/demos/demo_for_ahk_v1.ahk
+++ b/demos/demo_for_ahk_v1.ahk
@@ -1,19 +1,35 @@
-﻿
-; msgbox(A_DebuggerName)
-global GlobalVar := "Global"
+﻿globalVar := "Global"
+global SuperGlobalVar := "SuperGlobal"
 function()
 return
 function()
 {
+	globalVar := "Local"
+	SuperGlobalVar := "Local"
+	bool := true
 	str := "string"
+	if (str == "str") {
+		MsgBox Overwrite primitive variable!
+	}
+	str_multiline := "
+	(LTrim
+		line 1
+		line 2
+		line 3
+	)"
 	int := 123
 	float := 123.456
 
 	emptyArray := []
 	smallArray := [1, 2, { str: "string" }]
+    sparseArray := { 1: 1, 3: 3 }
+	arrayLike := { 1: 1, 2: 2, 3: 3, length: 3 }
 	bigArray := []
 	Loop 150 {
 		bigArray.push(A_Index)
+	}
+	if (bigArray == "str") {
+		MsgBox Overwrite object variable!
 	}
 
 	obj := { str: str, int: int, float: float }
@@ -25,11 +41,6 @@ function()
 	instance := new Cls()
 
 	enum := obj._NewEnum()
-}
-Array(params*)
-{
-	params.isArray := true
-	return params
 }
 class Cls
 {

--- a/demos/demo_for_ahk_v2.ahk
+++ b/demos/demo_for_ahk_v2.ahk
@@ -1,17 +1,35 @@
-﻿function()
+﻿globalVar := "Global"
+global SuperGlobalVar := "SuperGlobal"
+function()
 return
 function()
 {
+	globalVar := "Local"
+	SuperGlobalVar := "Local"
 	bool := true
 	str := "string"
+	if (str == "str") {
+		MsgBox("Overwrite primitive variable!")
+	}
+	str_multiline := "
+	(LTrim
+		line 1
+		line 2
+		line 3
+	)"
 	int := 123
 	float := 123.456
 
 	emptyArray := []
 	smallArray := [1, 2, { str: "string" }]
+    sparseArray := { 1: 1, 3: 3 }
+	arrayLike := { 1: 1, 2: 2, 3: 3, length: 3 }
 	bigArray := []
-	Loop 150  {
+	Loop 150 {
 		bigArray.push(A_Index)
+	}
+	if (bigArray == "str") {
+		MsgBox("Overwrite object variable!")
 	}
 
 	obj := { str: str, int: int, float: float }

--- a/src/debugger/handler/VariableParser.ts
+++ b/src/debugger/handler/VariableParser.ts
@@ -24,14 +24,17 @@ interface DbgpProperty {
 export class VariableParser {
 
     private static _properties = new Map<number, string>();
+    private static _propertyScopeIdMap = new Map<number, number>();
     private static _variableReferenceCounter = 10000;
 
     public static getPropertyNameByRef(ref: number): string {
         return this._properties.get(ref);
     }
+    public static getPropertyScopeByRef(ref: number): number {
+        return this._propertyScopeIdMap.get(ref);
+    }
 
-    public static parse(property: DbgpResponse, args: DebugProtocol.VariablesArguments): Variable[] {
-
+    public static parse(property: DbgpResponse, scopeId: number, args: DebugProtocol.VariablesArguments): Variable[] {
         let properties: DbgpProperty[];
 
         if (this._properties.has(args.variablesReference) == true
@@ -43,7 +46,7 @@ export class VariableParser {
                 const { children } = property.response;
                 properties = Array.isArray(children.property) ? children.property : [children.property];
             } else {
-                properties = []; 
+                properties = [];
             }
         }
 
@@ -81,6 +84,7 @@ export class VariableParser {
             if ('children' in property && attributes.type === 'object') {
                 variablesReference = this._variableReferenceCounter++;
                 this._properties.set(variablesReference, property.attributes.fullname);
+                this._propertyScopeIdMap.set(variablesReference, scopeId);
 
                 if (this.isArrayLikeProperty(property) === true) {
                     const length = this.getArrayLikeLength(property);


### PR DESCRIPTION
**By Google Translate from Japanese to English.**

## Known issues
The following issues arose in Node debugging as well.
In other words, it depends on my environment or it is a vscode specification.
The confirmed version of vscode is 1.44.0.

### Replacement of variables when an error occurs
If an error occurs when rewriting a variable, the variable name and value are temporarily replaced with another variable. This does not overwrite the actual value.

Occurs when you call setErrorResponse.

### Line breaks are lost when edited
The line break disappears when you edit a string that contains a line break. Even if it is not edited, it will disappear if you press Enter.

Also, the display becomes strange if you cancel it with Escape without editing.