### PR TITLE
support "A_LineFile" in "#Include"

### DIFF
--- a/src/provider/DefProvider.ts
+++ b/src/provider/DefProvider.ts
@@ -23,7 +23,12 @@ export class DefProvider implements vscode.DefinitionProvider {
         const includeMatch = text.match(/(?<=#include).+?\.(ahk|ext)\b/i);
         if (includeMatch) {
             const parent = document.uri.path.substr(0, document.uri.path.lastIndexOf("/"));
-            return new vscode.Location(vscode.Uri.file(includeMatch[0].trim().replace(/(%A_ScriptDir%|%A_WorkingDir%)/, parent)), new vscode.Position(0, 0));
+            const derefedPath = vscode.Uri.file(
+                includeMatch[0].trim()
+                    .replace(/(%A_ScriptDir%|%A_WorkingDir%)/, parent)
+                    .replace(/(%A_LineFile%)/, document.uri.path)
+            );
+            return new vscode.Location(derefedPath, new vscode.Position(0, 0));
         }
 
     }


### PR DESCRIPTION
**By Google Translate from Japanese to English.**

Supports `A_LineFile`.

In `AutoHotkey v2`, the relative path is`% A_LineFile% \ ..` instead of `A_WorkingDir \`.
This will show that there are many other users besides me.

I've confirmed the relative path specifications [here](https://www.autohotkey.com/v2/v2-changes.htm).
> #Include is relative to the directory containing the current file by default.