### PR TITLE
修复部分代码被识别成函数 ,造成崩溃

### DIFF
--- a/src/core/detect/detecter.ts
+++ b/src/core/detect/detecter.ts
@@ -159,7 +159,7 @@ export class Detecter {
 
         origin = origin != undefined ? origin : document.lineAt(line).text;
         const text = CodeUtil.purity(origin);
-        const refPattern = /\s*(([\u4e00-\u9fa5_a-zA-Z0-9]+)(?<!if|while)\s*\(.*?\))\s*(\{)?\s*/i
+        const refPattern = /\s*(([\u4e00-\u9fa5_a-zA-Z0-9]+)(?<!if|while)\(.*?\))\s*(\{)?\s*/i
         const methodMatch = text.match(refPattern);
         if (!methodMatch) {
             return;


### PR DESCRIPTION
修复部分代码被识别成函数 ,造成崩溃
a "" () a
msgbox % () a
像这两行