### PR TITLE
Add support for folding region-marker comments.

### DIFF
--- a/ahk.configuration.json
+++ b/ahk.configuration.json
@@ -34,5 +34,12 @@
         ["\"", "\""],
         ["'", "'"],
         ["%", "%"]
-	]
+	],
+    // Folding regions marked by ";region" and ";endregion" comments.
+    "folding": {
+        "markers": {
+            "start": "^\\s*\\;\\s*region\\b",
+            "end": "^\\s*\\;\\s*endregion\\b"
+        }
+    }
 }


### PR DESCRIPTION
Similar to how other languages use regions in VSCode, accept a comment marker `;` followed by the Keyword `region` (whitespace is ignored). Any other text can follow this word like a normal comment.
VS Code will then naturally support folding up that region until the next `;` `endregion` comment.
[Example Used](https://github.com/microsoft/vscode-extension-samples/blob/master/language-configuration-sample/language-configuration.json)

Example:
```autohotkey
/*
 * My AHK Script
 * It does nothing
 */

; region ==================== Initialisation ====================
#Persistent
#SingleInstance, Force
myVar := 0
; endregion ==============================================

;region ===================== Main ========================
#IfWinNotActive, ahk_exe chrome.exe
return
#IfWinNotActive
;endregion
```