### PR TITLE
Update ahk.configuration.json

### DIFF
--- a/ahk.configuration.json
+++ b/ahk.configuration.json
@@ -38,8 +38,8 @@
     // Folding regions marked by ";region" and ";endregion" comments.
     "folding": {
         "markers": {
-            "start": "^\\s*\\;\\s*region\\b",
-            "end": "^\\s*\\;\\s*endregion\\b"
+            "start": "\\s*\\;\\s*region\\b",
+            "end": "\\s*\\;\\s*endregion\\b"
         }
     }
 }


### PR DESCRIPTION
Removing the circumflex anchors will simplify the creation of block comments without the need for indentation.

```
/* ;region
No indentation required to allow
block comments to be folded.
*/ ;endregion
```