### PR TITLE
Add compiler options

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,6 +244,21 @@
 					"default": "C:/Program Files/AutoHotkey/Compiler/Ahk2Exe.exe",
 					"description": "Compiler path of autohotkey."
 				},
+				"vscode-ahk-plus.compileIcon": {
+					"type": "string",
+					"default": "",
+					"description": "Icon path for the compiled file."
+				},
+				"vscode-ahk-plus.compileBaseFile": {
+					"type": "string",
+					"default": "",
+					"description": "Base File (.bin) path for compiling (optional)."
+				},
+				"vscode-ahk-plus.compileMpress": {
+					"type": "boolean",
+					"default": false,
+					"description": "Use MPRESS (if present) to compress resulting exe."
+				},
 				"vscode-ahk-plus.documentPath": {
 					"type": "string",
 					"default": "C:/Program Files/AutoHotkey/AutoHotkey.chm",

--- a/src/common/global.ts
+++ b/src/common/global.ts
@@ -26,6 +26,7 @@ export class Global {
 }
 
 export enum ConfigKey {
-    compilePath = "compilePath", executePath = "executePath", enableIntelliSense = "enableIntelliSense",
+    compilePath = "compilePath", compileIcon = "compileIcon", compileBaseFile = "compileBaseFile",
+    compileMpress = "compileMpress", executePath = "executePath", enableIntelliSense = "enableIntelliSense",
     documentPath = "documentPath"
 }

--- a/src/service/runnerService.ts
+++ b/src/service/runnerService.ts
@@ -60,7 +60,16 @@ export class RunnerService {
         this.checkAndSaveActive();
         const pos = currentPath.lastIndexOf(".");
         const compilePath = currentPath.substr(0, pos < 0 ? currentPath.length : pos) + ".exe";
-        if (await Process.exec(`"${Global.getConfig(ConfigKey.compilePath)}" /in "${currentPath}" /out "${compilePath}"`, { cwd: `${res(currentPath, '..')}` })) {
+
+        let compileIcon = Global.getConfig(ConfigKey.compileIcon);
+        compileIcon = compileIcon ? `/icon "${compileIcon}"` : "";
+        let compileBaseFile = Global.getConfig(ConfigKey.compileBaseFile);
+        compileBaseFile = compileBaseFile ? `/bin "${compileBaseFile}"` : "";
+        let compileMpress = Global.getConfig(ConfigKey.compileMpress);
+        compileMpress = compileMpress ? "/mpress 1" : "";
+
+        const compileCommand = `"${Global.getConfig(ConfigKey.compilePath)}" /in "${currentPath}" /out "${compilePath}" ${compileIcon} ${compileBaseFile}" ${compileMpress}"`;
+        if (await Process.exec(compileCommand, { cwd: `${res(currentPath, '..')}` })) {
             vscode.window.showInformationMessage("compile success!");
         }
     }


### PR DESCRIPTION
I've added a few compilation options that I use regularly:
- Custom icon
- Base file for use in compilation (required when you want to compile in a different version from the dev environment)
- Compress the resulting file by [MPRESS](https://www.autohotkey.com/mpress/mpress_web.htm)

(I didn't check the code at all since I don't usually develop extensions.)